### PR TITLE
Add support for a custom list of hosts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ etc_hosts_add_all_hosts: false
 etc_hosts_enable_ipv6: true
 
 # Defines your primary dns suffix
-etc_hosts_pri_dns_name: vagrant.local
+etc_hosts_pri_dns_name:
 
 # Defines if node has static IP.
 etc_hosts_static_ip: false
@@ -17,3 +17,8 @@ etc_hosts_use_ansible_ssh_host: true
 
 # Defines if ansible_default_ipv4.address is used for defining hosts
 etc_hosts_use_default_ip_address: false
+
+# Defines a custom list of hosts (in the dictionary format {host: ip} ) 
+# Can be used for example to add all the hosts of a certain inventory group: 
+#  etc_hosts_add_custom_hosts: "{{ dict(groups['my_inventory_group'] | zip(groups['my_inventory_group'] | map('extract', hostvars, ['ansible_host']))) }}"
+etc_hosts_add_custom_hosts:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for ansible-etc-hosts
 - name: pre-reqs (RedHat)
-  yum:
+  package:
     name: ["libselinux-python"]
     state: present
   become: true
@@ -9,18 +9,18 @@
   until: result is successful
   when: >
     ansible_os_family == "RedHat" and
-    ansible_distribution != "Fedora"
+    ansible_python_version <= "2"
 
 - name: pre-reqs (RedHat)
-  dnf:
-    name: ["libselinux-python"]
+  package:
+    name: ["python3-libselinux"]
     state: present
   become: true
   register: result
   until: result is successful
   when: >
     ansible_os_family == "RedHat" and
-    ansible_distribution == "Fedora"
+    ansible_distribution >= "3"
 
 - name: main | updating /etc/hosts (localhost)
   template:

--- a/templates/etc/hosts.j2
+++ b/templates/etc/hosts.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 127.0.0.1 localhost
 
 {% if not etc_hosts_add_all_hosts %}
@@ -41,7 +43,7 @@
 {%   for host in play_hosts %}
 {%     if (hostvars[host]['ansible_domain'] == etc_hosts_pri_dns_name) or hostvars[host]['ansible_domain'] == '' %}
 {%       if etc_hosts_use_default_ip_address and not etc_hosts_use_ansible_ssh_host %}
-{{ hostvars[host]['ansible_default_ipv4']['address'] }} {{ hostvars[host]['ansible_fqdn'] }}.{{ etc_hosts_pri_dns_name }} {{ hostvars[host]['ansible_hostname'] }}
+{{ hostvars[host]['ansible_default_ipv4']['address'] }} {{ hostvars[host]['ansible_fqdn'] }} {{ hostvars[host]['ansible_hostname'] }}
 {%       elif not etc_hosts_use_default_ip_address and etc_hosts_use_ansible_ssh_host %}
 {%         if hostvars[host]['ansible_fqdn'] != (hostvars[host]['ansible_hostname']+ '.' + etc_hosts_pri_dns_name) %}
 {%           if hostvars[host]['ansible_ssh_host'] is defined %}
@@ -72,6 +74,28 @@
 {%     endif %}
 {%   endfor %}
 {% endif %}
+{% if etc_hosts_add_custom_hosts is defined and etc_hosts_add_custom_hosts %}
+{%   for key, val in etc_hosts_add_custom_hosts.items() %}
+{%-    if key != inventory_hostname -%}
+{%       if (etc_hosts_pri_dns_name is defined and etc_hosts_pri_dns_name) %}
+{%         if key.endswith(etc_hosts_pri_dns_name) %}
+{{ val }} {{ key }} {{ key[:-(etc_hosts_pri_dns_name|length+1)] }}
+{%         else %}
+{{ val }} {{ key }}
+{%         endif %}
+{%       elif (ansible_domain is defined and ansible_domain) %}
+{%         if key.endswith(ansible_domain) %}
+{{ val }} {{ key }} {{ key[:-(ansible_domain|length+1)] }}
+{%         else %}
+{{ val }} {{ key }}
+{%         endif %}
+{%       else %}
+{{ val }} {{ key }}
+{%       endif %}
+{%-    endif -%} 
+{%   endfor %}
+{% endif %}
+
 
 {% if etc_hosts_enable_ipv6 %}
 # The following lines are desirable for IPv6 capable hosts


### PR DESCRIPTION
Adds support for a custom list of hosts. Useful if you have a list(dict) of hosts you want to add to the hosts file.
It needs to be supplied in the dictionary format of `hostname: ip`

The list could be static or dynamically generated with ansible.
In my case I needed to add hosts from a certain group in my ansible inventory, the group itself is not a part of the play but I could extract it by looking up the hostvars for said group like this:
`"{{ dict(groups['my_inventory_group'] | zip(groups['my_inventory_group'] | map('extract', hostvars, ['ansible_host']))) }}"`
Decided to add this as a generic list method rather than adding support for just looking up different inventory groups, that way it could be adapted to whatever use case one might have.